### PR TITLE
Reuse spdx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#   SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+#   SPDX-License-Identifier: MIT
+#
+/build
 CMakeCache.txt
 CMakeFiles
 CMakeScripts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+# SPDX-License-Identifier: MIT
+
 cmake_minimum_required(VERSION 3.10)
 
 project(TurtleBrowser

--- a/LICENSES/BSD-2-Clause.txt
+++ b/LICENSES/BSD-2-Clause.txt
@@ -1,0 +1,24 @@
+
+ Copyright <year> <name> <email>
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) <year> <name>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packaging/CMakeLists.txt
+++ b/packaging/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+# SPDX-License-Identifier: MIT
+
 set(CPACK_PACKAGE_VENDOR "TurtleSec AS")
 
 set(CPACK_PACKAGE_INSTALL_DIRECTORY ${PROJECT_NAME})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+# SPDX-License-Identifier: MIT
+
 set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/src/resources/qml/AddressBar.qml
+++ b/src/resources/qml/AddressBar.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15

--- a/src/resources/qml/FramelessTopLevelWindow.qml
+++ b/src/resources/qml/FramelessTopLevelWindow.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtQuick.Window 2.15
 

--- a/src/resources/qml/LicenseNavigator.qml
+++ b/src/resources/qml/LicenseNavigator.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtQuick.Controls 1.4 as Classic
 import QtQuick.Controls.Styles 1.4 as ClassicStyles

--- a/src/resources/qml/LicensePage.qml
+++ b/src/resources/qml/LicensePage.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Controls 2.15

--- a/src/resources/qml/TabToolbar.qml
+++ b/src/resources/qml/TabToolbar.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15

--- a/src/resources/qml/TopLevelWindow.qml
+++ b/src/resources/qml/TopLevelWindow.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQml 2.15
 import QtQml.Models 2.15
 import QtQuick 2.15

--- a/src/resources/qml/WebPage.qml
+++ b/src/resources/qml/WebPage.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQml 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15

--- a/src/resources/qml/main.qml
+++ b/src/resources/qml/main.qml
@@ -1,3 +1,6 @@
+/* SPDX-FileCopyrightText: (c) 2018 Patricia Aas
+ * SPDX-License-Identifier: MIT
+ */
 import QtQuick 2.15
 import QtWebEngine 1.10
 


### PR DESCRIPTION
REUSE (https://reuse.software/) is an effort to tag software sources with machine-readable copyright and licensing information, which simplifies license checking in the supply-chain.

This branch just gets **started** on license-tagging, and gets you to this state of license-tagging-wholesomeness:

* Bad licenses:
* Deprecated licenses:
* Licenses without file extension:
* Missing licenses:
* Unused licenses:
* Used licenses: BSD-2-Clause, MIT
* Read errors: 0
* Files with copyright information: 245 / 501
* Files with license information: 12 / 501

(Information from the "REUSE linter"). Since you're doing the Right Thing (tm) by including all the license texts you might be sympathetic to machine-readable versions of the same, since that would have simplified your `src/resources/licenses` considerably.