### PR TITLE
Added trouble shooting section to BUILD_MACOS.md

### DIFF
--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -38,7 +38,7 @@ Open the CMakeLists.txt file in the root folder of the turtlebrowser project in 
 **Conan**
 
 There seems to be a problem with Conan installed via Homebrew. 
-Therefore, install it via PIP `pip install conan` and your version `1.34.0` minimum. 
+Therefore, install it via PIP instead `pip install conan` and your version should be `1.34.0` minimum. 
 If you have an older version, it can be updated running `pip install -U conan`. 
 
 **Python**

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -32,3 +32,12 @@ Install XCode (App Store)
 Install Node.js https://nodejs.org/en/download/
 
 Open the CMakeLists.txt file in the root folder of the turtlebrowser project in CLion.
+
+
+## Troubleshooting
+
+**Python**
+
+- Conan utilise Python3 but Chromium depends on Python2.7 to build. 
+  Therefore using Python3 can cause problems (i.e. Anaconda/Conda) 
+  the system include Python2.7 will allow both Conan to work and Chromium to build 

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -33,19 +33,24 @@ Install Node.js https://nodejs.org/en/download/
 
 Open the CMakeLists.txt file in the root folder of the turtlebrowser project in CLion.
 
-
 ## Troubleshooting
+
+**Conan**
+
+There seems to be a problem with Conan installed via Homebrew. 
+Therefore, install it via PIP `pip install conan` and your version `1.34.0` minimum. 
+If you have an older version, it can be updated running `pip install -U conan`. 
 
 **Python**
 
-- Conan utilise Python3 but Chromium depends on Python2.7 to build. 
+- Conan utilise Python3, but Chromium depends on Python2.7 to build. 
   Therefore using Python3 can cause problems (i.e. Anaconda/Conda) 
-  the system include Python2.7 will allow both Conan to work and Chromium to build 
+  the system includes Python2.7 will allow both Conan to work and Chromium to build 
 
 **Homebrew Clang "Interference"**
 
-Turtlebrowser compilation is currently only tested with Apple LLVM stack. 
-If you are normally using LLVM installed via Homebrew it can interfere with the build process. 
+Turtlebrowser compilation is currently only tested with the Apple LLVM stack. 
+If you usually are using LLVM installed via Homebrew, it can interfere with the build process. 
 Below is a list of environment variable changes known to affect the build process. 
 These should be removed before a build is attempted. 
 
@@ -53,12 +58,10 @@ These should be removed before a build is attempted.
 - `export LIBRARY_PATH="/usr/local/lib:$LIBRARY_PATH"`
 - `export CPLUS_INCLUDE_PATH="/usr/local/include:$CPLUS_INCLUDE_PATH"`
 
-
-
-
-
-**Conan**
-
-- install conan through python/pip not brew 
-
 **Xcode**
+
+Get the right version of Xcode or activate Xcode after a macOS update. 
+To check if it setup correctly run `xcodebuild -version && xcodebuild -showsdks`.
+If the output gives the version and SDK, you expect then you are set to go. 
+If it is not or it is empty, run the command `sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer`
+

--- a/BUILD_MACOS.md
+++ b/BUILD_MACOS.md
@@ -41,3 +41,24 @@ Open the CMakeLists.txt file in the root folder of the turtlebrowser project in 
 - Conan utilise Python3 but Chromium depends on Python2.7 to build. 
   Therefore using Python3 can cause problems (i.e. Anaconda/Conda) 
   the system include Python2.7 will allow both Conan to work and Chromium to build 
+
+**Homebrew Clang "Interference"**
+
+Turtlebrowser compilation is currently only tested with Apple LLVM stack. 
+If you are normally using LLVM installed via Homebrew it can interfere with the build process. 
+Below is a list of environment variable changes known to affect the build process. 
+These should be removed before a build is attempted. 
+
+- `export PATH="/usr/local/opt/llvm/bin:$PATH"`
+- `export LIBRARY_PATH="/usr/local/lib:$LIBRARY_PATH"`
+- `export CPLUS_INCLUDE_PATH="/usr/local/include:$CPLUS_INCLUDE_PATH"`
+
+
+
+
+
+**Conan**
+
+- install conan through python/pip not brew 
+
+**Xcode**


### PR DESCRIPTION
I added a troubleshooting section to the BUILD_MACOS.md file describing issues with conan, python, Xcode, and interference from homebrew clang environmental variable settings.